### PR TITLE
Adding -y to apt.

### DIFF
--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -45,15 +45,15 @@ else
 fi
 
 # Install dependencies
-sudo apt update
-sudo apt install libxml2-utils network-manager abootimg sshpass device-tree-compiler
+sudo apt update -y
+sudo apt install libxml2-utils network-manager abootimg sshpass device-tree-compiler -y
 # Previous to 18.04, simg2img was in android-tools-fsutils
 if [[ $(lsb_release -rs) == "16.04" ]] ; then
-  sudo apt install android-tools-fsutils
+  sudo apt install android-tools-fsutils -y
 else
-  sudo apt install simg2img qemu-user-static
+  sudo apt install simg2img qemu-user-static -y
 fi
 
 # Install dependency for secure boot
-sudo apt install openssh-server
+sudo apt install openssh-server -y
 


### PR DESCRIPTION
If we add -y to apt, it does not ask us if we want to do the action or not. It directly does the action. The user does not need to keep a watch on the script to see if everything is installed.