### PR TITLE
Improve documents about installation of SD card in AGX Xavier

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,11 @@ Install dependencies for flashing the Jetson. This script must be run on the hos
 
 ### flash_jetson_external_storage.sh
 Flashes the Jetson attached to the host via a USB cable. This script must be run on the host machine. The Jetson must be in Force Recovery Mode.
-The script prepares external storage attached to the Jetson, either NVMe or USB. Default is NVMe as the Orin and Xaviers have M.2 Key M slots which accept NVMe SSDs. The SSDs must be PCIE, SATA does not work. For the Xavier NX and Orin NX and Orin Nano, this flashes the QSPI memory on the Jetson module.
+The script prepares external storage attached to the Jetson, either NVMe, USB or SD Card. Default is NVMe as the Orin and Xaviers have M.2 Key M slots which accept NVMe SSDs. The SSDs must be PCIE, SATA does not work. For the Xavier NX and Orin NX and Orin Nano, this flashes the QSPI memory on the Jetson module.
 ```
 Usage: ./flash_jetson_external_storage [OPTIONS]
   No option flashes to nvme0n1p1 by default
-  -s | --storage - Specific storage media to flash; sda1 or nvme0n1p1
+  -s | --storage - Specific storage media to flash; sda1, nvme0n1p1 or mmcblk1p1
   -h | --help    - displays this message
 ```
  

--- a/flash_jetson_external_storage.sh
+++ b/flash_jetson_external_storage.sh
@@ -51,7 +51,7 @@ function help_func
 {
   echo "Usage: ./flash_jetson_external_storage [OPTIONS]"
   echo "   No option flashes to nvme0n1p1 by default"
-  echo "   -s | --storage - Specific storage media to flash; sda1 or nvme0n1p1"
+  echo "   -s | --storage - Specific storage media to flash; sda1, nvme0n1p1 or mmcblk1p1"
   echo "   -h | --help - displays this message"
 }
 


### PR DESCRIPTION
I confirmed the installation via `./flash_jetson_external_storage.sh mmcblk1p1` to SD card on AGX Xavier.
So, I added a description of this.

Thank you for providing good tools.
I was looking for tools that can install to SD card on AGX Xavier.
(Maybe now, not officially supported about the SD Card installation.)

### Environment
- Ubuntu 18.04 (Host)
- Jetson AGX Xavier Development Kit (Target)