### PR TITLE
Bug - Adjusting nvsdkmanager_flash.sh to avoid 14GB nvme SSD partition

### DIFF
--- a/flash_jetson_external_storage.sh
+++ b/flash_jetson_external_storage.sh
@@ -10,6 +10,9 @@ LINUX_FOR_TEGRA_DIRECTORY="$JETSON_FOLDER/Linux_for_Tegra"
 # Some helper functions. These scripts only flash Jetson Orins and Xaviers
 # https://docs.nvidia.com/jetson/archives/r35.4.1/DeveloperGuide/text/IN/QuickStart.html#jetson-modules-and-configurations
 
+#Swapping config xml or Xavier devices - without this change the system root is constrained to 14GB 
+sed -i 's/flash_l4t_t194_nvme.xml/flash_l4t_external.xml/' ./$JETSON_FOLDER/Linux_for_Tegra/nvsdkmanager_flash.sh
+
 declare -a device_names=(
     "jetson-agx-orin-devkit"
     "jetson-agx-xavier-devkit"


### PR DESCRIPTION
- Adding a quick change to `flash_jetson_external_storage.sh` that modifies `nvsdkmanager_flash.sh at the current L4T version 
- Without this change flashing resulted in a 14GB partition that was difficult to change with gparted due to the fact that it was the the system root/ used for boot etc
- the solution  that lead to this quick change was taken from this tech support [solution] (https://forums.developer.nvidia.com/t/jetpack-5-1-2-l4t-35-4-1-is-now-live/262035/5)

**Environment**
- Ubuntu 22.04 (Host)
- Jetson NX Xavier 8GB Development Kit (Target)
- Jetson AGX Xavier 32GB Development Kit (Target)

**Test Results** - Tested succesfully for changes with Jetpack 5.4.1 and a 500GB WD Blue NVMe SSD